### PR TITLE
Replace 'with' by 'env' in master github workflow

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Release Maven package
         #run: ./gradlew publishJvmPublicationToSonatypeRepository -PremoveSnapshot
         run: ./gradlew assemble
-        with:
+        env:
           OSSRH_USERNAME: ${{ secrets.SONATYPE_OSSRH_USERNAME }}
           OSSRH_PASSWORD: ${{ secrets.SONATYPE_OSSRH_PASSWORD }}
           SIGNING_PRIVATE_KEY: ${{ secrets.PGP_PRIVATE_KEY }}


### PR DESCRIPTION
This PR fixes a defect in the branch `kmp-structure` that prevents the `master.yml` action from starting.