### PR TITLE
Enable all tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Change wrapper permission
         run: chmod +x ./gradlew
       - name: Test
-        run: ./gradlew clean test
+        run: ./gradlew clean allTests
 
   artifact:
     name: Publish - Nexus

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Change wrapper permission
         run: chmod +x ./gradlew
       - name: Test
-        run: ./gradlew clean test
+        run: ./gradlew clean allTests
 
   artifact:
     name: Publish - Nexus


### PR DESCRIPTION
The task `test` only runs test for JVM by default. The task `allTests` should be used instead.