### PR TITLE
fix: unary negate of numbers in JS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ hs_err_pid*
 .gradle/
 target/
 build/
+kotlin-js-store/

--- a/src/commonMain/kotlin/org/hisp/dhis/lib/expression/ast/Typed.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/lib/expression/ast/Typed.kt
@@ -57,7 +57,7 @@ fun interface Typed {
             else value
         }
 
-        private fun isNonFractionValue(value: Number): Boolean {
+        fun isNonFractionValue(value: Number): Boolean {
             return value.toDouble() % 1.0 == 0.0
         }
     }

--- a/src/commonMain/kotlin/org/hisp/dhis/lib/expression/ast/UnaryOperator.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/lib/expression/ast/UnaryOperator.kt
@@ -12,7 +12,6 @@ enum class UnaryOperator(val symbol: String, private val returnType: ValueType) 
     override fun getValueType(): ValueType {
         return returnType
     }
-
     companion object {
 
         fun fromSymbol(symbol: String): UnaryOperator {
@@ -23,7 +22,7 @@ enum class UnaryOperator(val symbol: String, private val returnType: ValueType) 
             if (value == null) {
                 return null
             }
-            return if (value is Int) -value.toInt() else -value.toDouble()
+            return -value.toDouble()
         }
     }
 }

--- a/src/commonTest/kotlin/org/hisp/dhis/lib/expression/MathExpressionTest.kt
+++ b/src/commonTest/kotlin/org/hisp/dhis/lib/expression/MathExpressionTest.kt
@@ -82,17 +82,14 @@ internal class MathExpressionTest {
         assertEquals(-2.25141952945498701E18, evaluate("(1+2)*-3^(9*4)*5+6"))
         assertEquals(-787313.0, evaluate("1+2*-3^9*4*5+6"))
     }
-
-    companion object {
-        private fun assertEquals(expected: Double, actual: Number) {
-            kotlin.test.assertEquals(expected, actual.toDouble(), 0.000001)
-        }
-
-        private fun evaluate(expression: String): Number {
-            val expr = Expression(expression)
-            val clean: (String) -> String = { str: String -> str.replace("\\s+".toRegex(), "") }
-            kotlin.test.assertEquals(clean(expression), clean(expr.normalise()))
-            return expr.evaluate() as Number
-        }
+    private fun assertEquals(expected: Double, actual: Number) {
+        kotlin.test.assertEquals(expected, actual.toDouble(), 0.000001)
     }
+    private fun evaluate(expression: String): Number {
+        val expr = Expression(expression)
+        val clean: (String) -> String = { str: String -> str.replace("\\s+".toRegex(), "") }
+        kotlin.test.assertEquals(clean(expression), clean(expr.normalise()))
+        return expr.evaluate() as Number
+    }
+
 }

--- a/src/commonTest/kotlin/org/hisp/dhis/lib/expression/ast/UnaryOperatorTest.kt
+++ b/src/commonTest/kotlin/org/hisp/dhis/lib/expression/ast/UnaryOperatorTest.kt
@@ -1,0 +1,16 @@
+package org.hisp.dhis.lib.expression.ast
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+internal class UnaryOperatorTest {
+
+    @Test
+    fun testNegate_Integer() {
+        assertEquals(-42.0, UnaryOperator.negate(42))
+    }
+    @Test
+    fun testNegate_Double() {
+        assertEquals(-1.4, UnaryOperator.negate(1.4))
+    }
+}


### PR DESCRIPTION
The issue was twofold:
1. JS did not evaluate `value is Int` to false for a double value so it went the integer path and did `-value.toInt()`
2. the `negate` function always had returned a double no matter the input which was important in some calculations to keep doing math for bigger numbers
