### PR TITLE
fix: update sonatype url

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -88,6 +88,8 @@ publicationConfig(dokkaHtmlJar)
 nexusPublishing {
     this.repositories {
         sonatype {
+            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
             username.set(ossrhUsername)
             password.set(ossrhPassword)
         }


### PR DESCRIPTION
Update sonatype url according to [Gradle nexus plugin doc](https://github.com/gradle-nexus/publish-plugin#publishing-to-maven-central-via-sonatype-ossrh)