### PR TITLE
fix: hide ExpressionFunctions inside Expression

### DIFF
--- a/src/commonMain/kotlin/org/hisp/dhis/lib/expression/Expression.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/lib/expression/Expression.kt
@@ -98,15 +98,15 @@ class Expression(
         return evaluate({ _: String -> null }, ExpressionData())
     }
 
-    fun evaluate(functions: ExpressionFunctions, data: ExpressionData): Any? {
-        return evaluate(root, functions, data)
+    fun evaluate(unsupported: (String) -> Any?, data: ExpressionData): Any? {
+        return evaluate(root, { name: String -> unsupported(name) }, data)
     }
 
     fun collectProgramVariables(): Set<Variable> {
         return collectVariables(root, VariableType.PROGRAM)
     }
 
-    fun generateSQL(functions: ExpressionFunctions, sqlByProgramVariable: Map<Variable, String>): String {
+    fun generateSQL(unsupported: (String) -> Any?, sqlByProgramVariable: Map<Variable, String>): String {
         return "" //TODO
     }
 

--- a/src/jsMain/kotlin/org.hisp.dhis.lib.expression.js/ExpressionJs.kt
+++ b/src/jsMain/kotlin/org.hisp.dhis.lib.expression.js/ExpressionJs.kt
@@ -29,8 +29,8 @@ class ExpressionJs(expression: String, mode: String) {
         return expr.collectProgramVariablesNames().toTypedArray()
     }
 
-    fun evaluate(unsupported: (String)-> Any?, data: ExpressionDataJs): Any? {
-        return expr.evaluate({ name: String -> unsupported(name) }, toExpressionDataJava(data))
+    fun evaluate(unsupported: (String) -> Any?, data: ExpressionDataJs): Any? {
+        return expr.evaluate(unsupported, toExpressionDataJava(data))
     }
 
     fun collectProgramVariables(): Array<VariableJs> {


### PR DESCRIPTION
It appears that `ExpressionFunctions` cannot be implemented in Java by only overriding the abstract function and those that should be overridden. Therefore only the behaviour of the "undefined function name" function is exposed.  