### PR TITLE
Publish NPM beta version on push to main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,8 +20,8 @@ jobs:
         run: chmod +x ./gradlew
       - name: Test
         run: ./gradlew clean allTests
+
   publish:
-    name: Publish - Nexus
     runs-on: ubuntu-latest
     needs: unit-test
     steps:
@@ -34,8 +34,19 @@ jobs:
           cache: 'gradle'
       - name: Change wrapper permission
         run: chmod +x ./gradlew
-      - name: Release Maven package
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
+
+      - name: Release Maven package (snapshot)
         run: ./gradlew publishAllPublicationsToSonatypeRepository
         env:
           OSSRH_USERNAME: ${{ secrets.SONATYPE_OSSRH_USERNAME }}
           OSSRH_PASSWORD: ${{ secrets.SONATYPE_OSSRH_PASSWORD }}
+
+      - name: Release NPMJS package (beta)
+        run: |
+          ./gradlew packJsPackage
+          bash .github/workflows/publish-npmjs-beta.sh
+        env:
+          NPMJS_TOKEN: ${{ secrets.NPMJS_TOKEN }}

--- a/.github/workflows/publish-npmjs-beta.sh
+++ b/.github/workflows/publish-npmjs-beta.sh
@@ -1,0 +1,29 @@
+set -x
+
+cd build/packages/js || exit
+
+# Set authentication token for npmjs registry
+npm set //registry.npmjs.org/:_authToken="$NPMJS_TOKEN"
+
+# Set 'beta' suffix in the version starting with beta.0
+sed -i -e 's/-SNAPSHOT"/-beta.0"/g' package.json
+
+# Try to upload the beta version. If it is not available, increase the beta number and try again.
+# Iterate a maximum of MAX_ITERATION times.
+n=1
+MAX_ITERATIONS=30
+while [ $n -le $MAX_ITERATIONS ]; do
+  if ! output=$(npm publish --tag beta 2>&1); then
+    if [[ "$output" == *"ERR! code E403"* ]]; then
+      # This error code is likely to be thrown when the version already exists
+      # Increase beta version number to try again
+      npm version prerelease
+      n=$(( n + 1 ))
+    else
+      exit 1
+    fi
+  else
+    # If upload is successful, exit
+    exit 0
+  fi
+done

--- a/buildSrc/src/main/kotlin/npm-publish-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/npm-publish-conventions.gradle.kts
@@ -4,8 +4,6 @@ plugins {
     id("dev.petuska.npm.publish")
 }
 
-val npmjsToken: String? = System.getenv("NPMJS_TOKEN")
-
 project.afterEvaluate {
     npmPublish {
         access.set(NpmAccess.PUBLIC)
@@ -30,11 +28,6 @@ project.afterEvaluate {
                         "access" by "public"
                     }
                 }
-            }
-        }
-        registries {
-            npmjs {
-                authToken.set(npmjsToken)
             }
         }
     }


### PR DESCRIPTION
This PR adds the capability to publish a beta package to NPMJS registry. This publication only happens on merge to main.

The plugin `npm-publish` is only used to build the package.json file. The actual publication is done in a separate script that uses `npm` commands directly.

It depends on `NPMJS_TOKEN` variable for authentication. This variable is set in DHIS2 organization, but it is not enabled for this repository. It must be enabled before merging to main.