### PR TITLE
fix: separate Nyx config file

### DIFF
--- a/.github/workflows/job-publish.yml
+++ b/.github/workflows/job-publish.yml
@@ -22,8 +22,10 @@ jobs:
         with:
           node-version: 14.x
 
-      - name: Create version tag
-        run: ./gradlew :nyxMark
+      - name: Create tag and publish Github release
+        run: ./gradlew :nyxPublish
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish Maven
         run: ./.github/workflows/scripts/publish-maven.sh

--- a/.nyx.yaml
+++ b/.nyx.yaml
@@ -1,0 +1,57 @@
+---
+# starting from the "simple" preset gives us:
+# - the Conventional Commits convention
+preset: "simple"
+changelog:
+  path: "CHANGELOG.md"
+  sections:
+    "Added": "^feat$"
+    "Fixed": "^fix$"
+releaseTypes:
+  enabled:
+    - mainline
+    - maturity
+    - internal
+  publicationServices:
+    - github
+  items:
+    mainline:
+      description: "{{#fileContent}}CHANGELOG.md{{/fileContent}}"
+      filterTags: "^({{configuration.releasePrefix}})?([0-9]\\d*)\\.([0-9]\\d*)\\.([0-9]\\d*)$"
+      gitPush: "true"
+      gitTag: "true"
+      matchBranches: "^(master|main)$"
+      matchEnvironmentVariables:
+        CI: "^true$"
+      matchWorkspaceStatus: "CLEAN"
+      publish: "true"
+    maturity:
+      description: "{{#fileContent}}CHANGELOG.md{{/fileContent}}"
+      collapseVersions: true
+      collapsedVersionQualifier: "{{#sanitizeLower}}{{branch}}{{/sanitizeLower}}"
+      filterTags: "^({{configuration.releasePrefix}})?([0-9]\\d*)\\.([0-9]\\d*)\\.([0-9]\\d*)(-(alpha|beta)(\\.([0-9]\\d*))?)?$"
+      gitPush: "true"
+      gitTag: "true"
+      matchBranches: "^(alpha|beta)$"
+      matchEnvironmentVariables:
+        CI: "^true$"
+      matchWorkspaceStatus: "CLEAN"
+      publish: "true"
+      publishPreRelease: "true"
+    internal:
+      collapseVersions: true
+      collapsedVersionQualifier: "internal"
+      gitPush: "false"
+      gitTag: "false"
+      identifiers:
+        -
+          qualifier: "{{#timestampYYYYMMDDHHMMSS}}{{timestamp}}{{/timestampYYYYMMDDHHMMSS}}"
+          position: "BUILD"
+      publish: "false"
+services:
+  github:
+    type: "GITHUB"
+    options:
+      AUTHENTICATION_TOKEN: "{{#environmentVariable}}GH_TOKEN{{/environmentVariable}}"
+      REPOSITORY_NAME: "expression-parser"
+      REPOSITORY_OWNER: "dhis2"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,8 +10,4 @@ plugins {
     id("com.mooltiverse.oss.nyx") version "2.5.2"
 }
 
-configure<com.mooltiverse.oss.nyx.gradle.NyxExtension> {
-    preset.set("extended")
-}
-
 rootProject.name = "expression-parser"


### PR DESCRIPTION
Enables the publication of github releases on every beta or main publication. Release are created as:
- beta branch -> pre-release
- main branch -> release

The PRs separates the Nyx configuration to its own file instead of using the defaults presets. In this way, we have more control on the behavior. 