### PR TITLE
fix: ship esmodule and commonjs

### DIFF
--- a/.github/workflows/scripts/publish-npm.sh
+++ b/.github/workflows/scripts/publish-npm.sh
@@ -3,6 +3,9 @@ set -x
 branch=$(git rev-parse --abbrev-ref HEAD)
 
 ./gradlew packJsPackage
+./gradlew packJsPackage -PuseCommonJs
+
+exit
 cd build/packages/js || exit
 
 # Set authentication token for npmjs registry

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,11 @@ kotlin {
     }
     js {
         nodejs()
-        useEsModules()
+        if (project.hasProperty("useCommonJs")) {
+            useCommonJs()
+        } else {
+            useEsModules()
+        }
         binaries.library()
         generateTypeScriptDefinitions()
     }

--- a/buildSrc/src/main/kotlin/npm-publish-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/npm-publish-conventions.gradle.kts
@@ -4,8 +4,6 @@ plugins {
     id("dev.petuska.npm.publish")
 }
 
-val npmjsToken: String? = System.getenv("NPMJS_TOKEN")
-
 project.afterEvaluate {
     npmPublish {
         access.set(NpmAccess.PUBLIC)
@@ -15,9 +13,12 @@ project.afterEvaluate {
                 readme.set(File("./README.md"))
                 packageJson {
                     "module" by "${project.name}.mjs"
-                    "main" by ""
+                    "main" by "${project.name}.js"
                     "exports" by {
-                        "import" by "./${project.name}.mjs"
+                        "." by {
+                            "import" by "./${project.name}.mjs"
+                            "require" by "./${project.name}.js"
+                        }
                     }
                     "author" by "${Props.AUTHOR_NAME} <${Props.AUTHOR_EMAIL}>"
                     "description" by Props.DESCRIPTION
@@ -32,20 +33,6 @@ project.afterEvaluate {
                     "private" by false
                 }
             }
-        }
-        registries {
-            npmjs {
-                authToken.set(npmjsToken)
-            }
-        }
-    }
-
-    tasks.named("assembleJsPackage") {
-        doLast {
-            val file = file("${layout.buildDirectory.get()}/packages/js/package.json")
-            val mainRegex = "\n    \"main\": \"\","
-            val removedMain = file.readText().replace(mainRegex, "")
-            file.writeText(removedMain)
         }
     }
 }


### PR DESCRIPTION
This PR adds the capability to ship both module types (esmodule and commonjs) together. Files are located in the same folder with same names and different extensions (`.js` for commonjs and `.mjs` for esmodule).

The solution was to conditionally trigger esmodule build or commonjs build depending on a parameter (`-PuseCommonJs`). By default it uses esmodule. The publish script runs two builds and their output files are sent to the same output folder.