### PR TITLE
fix: use JsMap wrapper (JS component)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -75,7 +75,11 @@ kotlin {
         }
         val jvmMain by getting
         val jvmTest by getting
-        val jsMain by getting
+        val jsMain by getting {
+            dependencies {
+                api("org.jetbrains.kotlin-wrappers:kotlin-js:1.0.0-pre.722")
+            }
+        }
         val jsTest by getting
         val nativeMain by getting
         val nativeTest by getting

--- a/src/jsMain/kotlin/org.hisp.dhis.lib.expression.js/Entry.kt
+++ b/src/jsMain/kotlin/org.hisp.dhis.lib.expression.js/Entry.kt
@@ -1,5 +1,0 @@
-package org.hisp.dhis.lib.expression.js
-
-@OptIn(ExperimentalJsExport::class)
-@JsExport
-data class Entry<K,V>(val key: K, val value: V)

--- a/src/jsMain/kotlin/org.hisp.dhis.lib.expression.js/ExpressionDataJs.kt
+++ b/src/jsMain/kotlin/org.hisp.dhis.lib.expression.js/ExpressionDataJs.kt
@@ -1,11 +1,13 @@
 package org.hisp.dhis.lib.expression.js
 
+import js.collections.JsMap
+
 @OptIn(ExperimentalJsExport::class)
 @JsExport
 data class ExpressionDataJs(
-    val programRuleVariableValues: Array<Entry<String, VariableValueJs>> = emptyArray(),
-    val programVariableValues: Array<Entry<String, Any>> = emptyArray(),
-    val supplementaryValues: Array<Entry<String, Array<String>>> = emptyArray(),
-    val dataItemValues: Array<Entry<DataItemJs, Any>> = emptyArray(),
-    val namedValues: Array<Entry<String, Any>> = emptyArray()
+    val programRuleVariableValues: JsMap<String, VariableValueJs> = JsMap(),
+    val programVariableValues: JsMap<String, Any> = JsMap(),
+    val supplementaryValues: JsMap<String, Array<String>> = JsMap(),
+    val dataItemValues: JsMap<DataItemJs, Any> = JsMap(),
+    val namedValues: JsMap<String, Any> = JsMap()
 )

--- a/src/jsMain/kotlin/org.hisp.dhis.lib.expression.js/ExpressionJs.kt
+++ b/src/jsMain/kotlin/org.hisp.dhis.lib.expression.js/ExpressionJs.kt
@@ -1,5 +1,6 @@
 package org.hisp.dhis.lib.expression.js
 
+import js.collections.JsMap
 import kotlinx.datetime.LocalDate
 import org.hisp.dhis.lib.expression.Expression
 import org.hisp.dhis.lib.expression.ast.AggregationType
@@ -41,11 +42,11 @@ class ExpressionJs(expression: String, mode: String) {
         return expr.collectUIDs().map(::toIdJS).toTypedArray()
     }
 
-    fun describe(displayNames: Array<Entry<String, String>>): String {
+    fun describe(displayNames: JsMap<String, String>): String {
         return expr.describe(toMap(displayNames, { it }, { it }))
     }
 
-    fun validate(displayNamesKeys: Array<Entry<String, String>>) {
+    fun validate(displayNamesKeys: JsMap<String, String>) {
         expr.validate(toMap(displayNamesKeys, { it }, { e -> ValueType.valueOf(e) }))
     }
 
@@ -53,7 +54,7 @@ class ExpressionJs(expression: String, mode: String) {
         return expr.collectDataItemForRegenerate().map(::toDataItemJS).toTypedArray()
     }
 
-    fun regenerate(dataItemValues: Array<Entry<DataItemJs, Double>>): String {
+    fun regenerate(dataItemValues: JsMap<DataItemJs, Double>): String {
         return expr.regenerate(toMap(dataItemValues, ::toDataItemJava) { it })
     }
 
@@ -68,9 +69,9 @@ class ExpressionJs(expression: String, mode: String) {
     companion object {
         val MODES = Expression.Mode.entries.map { it.name }.toTypedArray()
 
-        internal fun <Kf, Vf, K, V> toMap(map: Array<Entry<Kf, Vf>>, key: (Kf) -> K, value: (Vf) -> V): Map<K, V> {
+        internal fun <Kf, Vf, K, V> toMap(map: JsMap<Kf, Vf>, key: (Kf) -> K, value: (Vf) -> V): Map<K, V> {
             val res : MutableMap<K, V> = mutableMapOf()
-            map.forEach { e -> res[key(e.key)] = value(e.value) }
+            map.forEach { v, k -> res[key(k)] = value(v) }
             return res;
         }
 


### PR DESCRIPTION
Uses Kotlin js wrappers to expose native JS Map instead of `Array<Entry>`.
