### PR TITLE
fix: Apply workaround to signing multiplatform projects

### DIFF
--- a/buildSrc/src/main/kotlin/maven-publish-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/maven-publish-conventions.gradle.kts
@@ -70,3 +70,10 @@ signing {
     useInMemoryPgpKeys(signingPrivateKey, signingPassword)
     sign(publishing.publications)
 }
+
+// Fix Gradle warning about signing tasks using publishing task outputs without explicit dependencies
+// https://github.com/gradle/gradle/issues/26091
+tasks.withType<AbstractPublishToMaven>().configureEach {
+    val signingTasks = tasks.withType<Sign>()
+    mustRunAfter(signingTasks)
+}


### PR DESCRIPTION
Related to this issue: https://github.com/gradle/gradle/issues/26091