### PR TITLE
fix: modify javadoc classifier

### DIFF
--- a/buildSrc/src/main/kotlin/maven-publish-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/maven-publish-conventions.gradle.kts
@@ -15,7 +15,7 @@ val dokkaHtml = tasks.findByName("dokkaHtml")!!
 val dokkaHtmlJar = tasks.register<Jar>("dokkaHtmlJar") {
     dependsOn(dokkaHtml)
     from(dokkaHtml.outputs)
-    archiveClassifier.set("docs")
+    archiveClassifier.set("javadoc")
 }
 
 publishing {


### PR DESCRIPTION
Nexus requires a javadoc artifact