### PR TITLE
feat: data comparison and coercion [DHIS2-18785]

### DIFF
--- a/src/commonMain/kotlin/org/hisp/dhis/lib/expression/Expression.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/lib/expression/Expression.kt
@@ -49,7 +49,14 @@ class Expression(
      * @see .evaluate
      */
     fun evaluate(): Any? {
-        return evaluate({ _: String -> null }, ExpressionData())
+        return evaluate(ExpressionData())
+    }
+
+    /**
+     * For testing only.
+     */
+    fun evaluate(data: ExpressionData): Any? {
+        return evaluate({ _: String -> null }, data)
     }
 
     fun evaluate(unsupported: (String) -> Any?, data: ExpressionData): Any? {

--- a/src/commonMain/kotlin/org/hisp/dhis/lib/expression/ast/Typed.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/lib/expression/ast/Typed.kt
@@ -14,14 +14,15 @@ fun interface Typed {
     companion object {
         fun toNumberTypeCoercion(value: Any?): Double? {
             if (value == null) return null
-            if (value is VariableValue) return toNumberTypeCoercion(value.valueOrDefault())
-            return if (value is Boolean) if (value == true) 1.0 else 0.0
-            else (value as? Number)?.toDouble() ?: value.toString().toDouble()
+            if (value is VariableValue) return toNumberTypeCoercion(toMixedTypeTypeCoercion(value))
+            if (value is Boolean) return if (value == true) 1.0 else 0.0
+            if (value is LocalDate) return value.toEpochDays().toDouble()
+            return (value as? Number)?.toDouble() ?: value.toString().toDouble()
         }
 
         fun toBooleanTypeCoercion(value: Any?): Boolean? {
             if (value == null) return null
-            if (value is VariableValue) return toBooleanTypeCoercion(value.valueOrDefault())
+            if (value is VariableValue) return toBooleanTypeCoercion(toMixedTypeTypeCoercion(value))
             if (value is Boolean) return value
             if (value is Number) {
                 require(isNonFractionValue(value)) { "Could not coerce Double '$value' to Boolean" }
@@ -32,7 +33,7 @@ fun interface Typed {
 
         fun toDateTypeCoercion(value: Any?): LocalDate? {
             if (value == null) return null
-            if (value is VariableValue) return toDateTypeCoercion(value.valueOrDefault())
+            if (value is VariableValue) return toDateTypeCoercion(toMixedTypeTypeCoercion(value))
             if (value is LocalDate) return value
             if (value is String) return LocalDate.parse(value)
             if (value is Instant) return value.toLocalDateTime(TimeZone.currentSystemDefault()).date
@@ -41,7 +42,7 @@ fun interface Typed {
 
         fun toStringTypeCoercion(value: Any?): String? {
             if (value == null) return null
-            if (value is VariableValue) return toStringTypeCoercion(value.valueOrDefault());
+            if (value is VariableValue) return toStringTypeCoercion(toMixedTypeTypeCoercion(value));
             if (value is Number) return  if (isNonFractionValue(value)) value.toInt().toString() else value.toString();
             return value.toString()
         }

--- a/src/commonTest/kotlin/org/hisp/dhis/lib/expression/VariableExpressionTest.kt
+++ b/src/commonTest/kotlin/org/hisp/dhis/lib/expression/VariableExpressionTest.kt
@@ -1,11 +1,17 @@
 package org.hisp.dhis.lib.expression
 
+import kotlinx.datetime.LocalDate
+import org.hisp.dhis.lib.expression.ExpressionMode.RULE_ENGINE_CONDITION
 import org.hisp.dhis.lib.expression.ast.NodeType
+import org.hisp.dhis.lib.expression.spi.ExpressionData
+import org.hisp.dhis.lib.expression.spi.ValueType
+import org.hisp.dhis.lib.expression.spi.VariableValue
 import org.hisp.dhis.lib.expression.syntax.ExpressionGrammar
 import org.hisp.dhis.lib.expression.syntax.Parser
 import org.hisp.dhis.lib.expression.util.TNode
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 /**
  * Tests that expressions with variable names are parsed into the expected AST structure.
@@ -46,6 +52,23 @@ internal class VariableExpressionTest {
         assertHasStructure(
             TNode.ofLevels(NodeType.FUNCTION, NodeType.ARGUMENT, NodeType.VARIABLE, NodeType.STRING),
             "d2:maxValue(\"varname\")")
+    }
+
+    @Test
+    fun testProgramRuleVariable_DateCompare() {
+        val data = ExpressionData().copy(
+            programRuleVariableValues = mapOf(
+                Pair(
+                    "event_date",
+                    VariableValue(ValueType.DATE, LocalDate.fromEpochDays(11).toString(), listOf(), null)),
+                Pair(
+                    "current_date",
+                    VariableValue(ValueType.DATE, LocalDate.fromEpochDays(10).toString(), listOf(), null)),
+            ))
+        val expr = Expression("V{event_date} > V{current_date}", RULE_ENGINE_CONDITION)
+        assertTrue(expr.evaluate(data) as Boolean)
+        val expr2 = Expression("V{event_date} - V{current_date}", RULE_ENGINE_CONDITION)
+        assertEquals(1.0, expr2.evaluate(data) as Double)
     }
 
     private fun assertHasStructure(expected: TNode, expression: String) {

--- a/src/commonTest/kotlin/org/hisp/dhis/lib/expression/ast/TypedTest.kt
+++ b/src/commonTest/kotlin/org/hisp/dhis/lib/expression/ast/TypedTest.kt
@@ -1,0 +1,14 @@
+package org.hisp.dhis.lib.expression.ast
+
+import kotlinx.datetime.LocalDate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+internal class TypedTest {
+
+    @Test
+    fun testToNumberTypeCoercion_Date() {
+        val date : LocalDate = LocalDate.fromEpochDays(20)
+        assertEquals(date.toEpochDays().toDouble(), Typed.toNumberTypeCoercion(date))
+    }
+}


### PR DESCRIPTION
### Summary
The central idea is to use `value.toEpochDays().toDouble()` when `value` is a `LocalDate` that should become a number to be used in a comparison or math operation.

While doing this I noticed that when coercing a `VariableValue` we use the raw `String` `value` without considering the `ValueType` of the variable first. I changed this by calling `toMixedTypeTypeCoercion` for variables first, which unpacks the value according to the `ValueType`. That result is the coerced by recursively calling the target coercion function on it, for example for a number:

```kotlin
if (value is VariableValue) return toNumberTypeCoercion(toMixedTypeTypeCoercion(value))
```

### Days vs. Milliseconds 

Since `LocalDate` has `toEpochDays` (instead of the more usual epoch milliseconds) I used this. If we want millisecond precision we need to add a multiplication factor. This would only be relevant when comparing a date with a number assuming the number is not number of days but number of milliseconds. But in context of the expression language it might make more sense to actually use days, not milliseconds.

### Automatic Tests
Added two simple tests to verify that variables of type date now can be used with comparison and math operators.