### PR TITLE
feat: short-circuiting for AND and OR operators [DHIS2-18849]

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ repositories {
     mavenCentral()
 }
 
-version = "1.1.2-SNAPSHOT"
+version = "1.1.3-SNAPSHOT"
 group = "org.hisp.dhis.lib.expression"
 
 if (project.hasProperty("removeSnapshotSuffix")) {

--- a/src/commonMain/kotlin/org/hisp/dhis/lib/expression/eval/Calculator.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/lib/expression/eval/Calculator.kt
@@ -22,8 +22,8 @@ internal class Calculator(
         return when (operator.getValue()) {
             BinaryOperator.EQ -> evalBinaryLogicOperator(BinaryOperator::equal, operator, this::evalToMixed)
             BinaryOperator.NEQ -> evalBinaryLogicOperator(BinaryOperator::notEqual, operator, this::evalToMixed)
-            BinaryOperator.AND -> evalBinaryOperator(BinaryOperator::and, operator, this::evalToBoolean)
-            BinaryOperator.OR -> evalBinaryOperator(BinaryOperator::or, operator, this::evalToBoolean)
+            BinaryOperator.AND -> evalBinaryLogicOperatorShortCircuit(BinaryOperator::and, operator, this::evalToBoolean, false)
+            BinaryOperator.OR -> evalBinaryLogicOperatorShortCircuit(BinaryOperator::or, operator, this::evalToBoolean, true)
             BinaryOperator.LT -> evalBinaryLogicOperator(BinaryOperator::lessThan, operator, this::evalToMixed)
             BinaryOperator.LE -> evalBinaryLogicOperator(BinaryOperator::lessThanOrEqual, operator, this::evalToMixed)
             BinaryOperator.GT -> evalBinaryLogicOperator(BinaryOperator::greaterThan, operator, this::evalToMixed)
@@ -335,6 +335,16 @@ internal class Calculator(
             val left = operator.child(0)
             val right = operator.child(1)
             val lVal = eval(left)
+            val rVal = eval(right)
+            return op(lVal, rVal)
+        }
+
+        private fun evalBinaryLogicOperatorShortCircuit(op: (Boolean?, Boolean?) -> Boolean?, operator: Node<*>,
+                                                        eval: (Node<*>) -> Boolean?, shortCircuitOn: Boolean): Boolean? {
+            val left = operator.child(0)
+            val right = operator.child(1)
+            val lVal = eval(left)
+            if (lVal != null && lVal == shortCircuitOn) return shortCircuitOn;
             val rVal = eval(right)
             return op(lVal, rVal)
         }


### PR DESCRIPTION
### Summary
When evaluating `a && b` or `a || b` b should only be evaluated when needed to determine the result. Meaning, `false && b` is always `false` and `true || b` is always `true` so `b` is not evaluated in such cases. 

### Automatic Testing
Added a test scenario based on the issue encountered by Pablo where `d2:daysBetween` fails for `null` arguments. Then a `&&` and an `||` guard is used with `d2:hasValue` to show that without the guard the failure is raised but with the guard it does compute without raising the failure of a `null` value argument.