### PR TITLE
[skip publish] chore: create version catalog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ hs_err_pid*
 
 .idea/
 .gradle/
+.kotlin/
 target/
 build/
 kotlin-js-store/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,8 +57,8 @@ kotlin {
         }
         val commonMain by getting {
             dependencies {
-                implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.4.1")
-                implementation("com.ionspin.kotlin:bignum:0.3.8")
+                implementation(libs.kotlinx.datetime)
+                implementation(libs.ionspin.bignum)
             }
         }
         val commonTest by getting {
@@ -70,7 +70,7 @@ kotlin {
         val jvmTest by getting
         val jsMain by getting {
             dependencies {
-                api("org.jetbrains.kotlin-wrappers:kotlin-js:1.0.0-pre.722")
+                api(libs.kotlinWrappers.js)
             }
         }
         val jsTest by getting

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -8,8 +8,8 @@ repositories {
 }
 
 dependencies {
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.22")
-    implementation("org.jetbrains.dokka:dokka-gradle-plugin:1.9.0")
-    implementation("io.github.gradle-nexus:publish-plugin:1.3.0")
-    implementation("dev.petuska:npm-publish-gradle-plugin:3.4.1")
+    implementation(libs.kotlin.plugin)
+    implementation(libs.dokka.plugin)
+    implementation(libs.nexusPublish.plugin)
+    implementation(libs.npmPublish.plugin)
 }

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,0 +1,7 @@
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,22 @@
+[versions]
+kotlin = "1.9.22"
+dokka = "1.9.0"
+nexusPublish = "1.3.0"
+npmPublish = "3.4.1"
+kotlinxDatetime = "0.4.1"
+bignum = "0.3.8"
+kotlinJsWrappers = "1.0.0-pre.722"
+
+[libraries]
+kotlin-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
+dokka-plugin = { group = "org.jetbrains.dokka", name = "dokka-gradle-plugin", version.ref = "dokka" }
+nexusPublish-plugin = { group = "io.github.gradle-nexus", name = "publish-plugin", version.ref = "nexusPublish" }
+npmPublish-plugin = { group = "dev.petuska", name = "npm-publish-gradle-plugin", version.ref = "npmPublish" }
+
+ionspin-bignum = { group = "com.ionspin.kotlin", name = "bignum", version.ref = "bignum" }
+kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime", version.ref = "kotlinxDatetime"}
+kotlinWrappers-js = { group = "org.jetbrains.kotlin-wrappers", name = "kotlin-js", version.ref = "kotlinJsWrappers"}
+
+[plugins]
+
+[bundles]


### PR DESCRIPTION
Creation of a gradle version catalog. It doesn't modify any version, just moves the dependency definition to the file `gradle/libs.versions.toml`.

The PR uses the syntax "group + name + versionRef", such as:
`ionspin-bignum = { group = "com.ionspin.kotlin", name = "bignum", version.ref = "bignum" }`

but there are many other syntax allowed. Up to you if you prefer other one ([check this](https://docs.gradle.org/current/userguide/version_catalogs.html#libraries)).