### PR TITLE
chore: Upgrade kotlin and libs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
           cache: 'gradle'
       - name: Change wrapper permission
@@ -35,10 +35,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
           cache: 'gradle'
       - name: Change wrapper permission

--- a/.github/workflows/publish_npm_beta.yml
+++ b/.github/workflows/publish_npm_beta.yml
@@ -11,10 +11,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
           cache: 'gradle'
       - name: Change wrapper permission

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
           cache: 'gradle'
       - name: Change wrapper permission
@@ -30,10 +30,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
           cache: 'gradle'
       - name: Change wrapper permission

--- a/.github/workflows/scripts/build-npm-package.sh
+++ b/.github/workflows/scripts/build-npm-package.sh
@@ -1,0 +1,16 @@
+set -x
+
+OUTPUT_DIR=$1
+GRADLE_PARAMS=$2
+
+BUILD_DIR="build/packages/js"
+
+rm -rf $OUTPUT_DIR && mkdir $OUTPUT_DIR
+./gradlew clean
+
+./gradlew packJsPackage $GRADLE_PARAMS
+mv $BUILD_DIR/* $OUTPUT_DIR/
+
+./gradlew packJsPackage -PuseCommonJs $GRADLE_PARAMS
+rm $BUILD_DIR/package.json
+mv $BUILD_DIR/* $OUTPUT_DIR/

--- a/.github/workflows/scripts/publish-npm-beta.sh
+++ b/.github/workflows/scripts/publish-npm-beta.sh
@@ -1,9 +1,9 @@
 set -x
 
-./gradlew packJsPackage
-./gradlew packJsPackage -PuseCommonJs
+OUTPUT_DIR="packageJs"
+sh $(dirname "$0")/build-npm-package.sh $OUTPUT_DIR
 
-cd build/packages/js || exit
+cd $OUTPUT_DIR || exit
 
 # Set authentication token for npmjs registry
 npm set //registry.npmjs.org/:_authToken="$NPMJS_TOKEN"

--- a/.github/workflows/scripts/publish-npm-prod.sh
+++ b/.github/workflows/scripts/publish-npm-prod.sh
@@ -1,9 +1,9 @@
 set -x
 
-./gradlew packJsPackage -PremoveSnapshotSuffix
-./gradlew packJsPackage -PremoveSnapshotSuffix -PuseCommonJs
+OUTPUT_DIR="packageJs"
+sh $(dirname "$0")/build-npm-package.sh $OUTPUT_DIR -PremoveSnapshotSuffix
 
-cd build/packages/js || exit
+cd $OUTPUT_DIR || exit
 
 # Set authentication token for npmjs registry
 npm set //registry.npmjs.org/:_authToken="$NPMJS_TOKEN"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,8 +17,8 @@ if (project.hasProperty("removeSnapshotSuffix")) {
 }
 
 kotlin {
+    jvmToolchain(17)
     jvm {
-        jvmToolchain(17)
         withJava()
         testRuns.named("test") {
             executionTask.configure {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ repositories {
     mavenCentral()
 }
 
-version = "1.1.5-SNAPSHOT"
+version = "1.1.6-SNAPSHOT"
 group = "org.hisp.dhis.lib.expression"
 
 if (project.hasProperty("removeSnapshotSuffix")) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ repositories {
     mavenCentral()
 }
 
-version = "1.1.4-SNAPSHOT"
+version = "1.1.5-SNAPSHOT"
 group = "org.hisp.dhis.lib.expression"
 
 if (project.hasProperty("removeSnapshotSuffix")) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin = "2.0.21"
 dokka = "1.9.0"
-nexusPublish = "1.3.0"
+nexusPublish = "2.0.0"
 npmPublish = "3.5.2"
 kotlinxDatetime = "0.6.1"
 bignum = "0.3.10"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,17 +1,17 @@
 [versions]
-kotlin = "1.9.22"
+kotlin = "2.0.21"
 dokka = "1.9.0"
 nexusPublish = "1.3.0"
-npmPublish = "3.4.1"
-kotlinxDatetime = "0.4.1"
-bignum = "0.3.8"
-kotlinJsWrappers = "1.0.0-pre.722"
+npmPublish = "3.5.2"
+kotlinxDatetime = "0.6.1"
+bignum = "0.3.10"
+kotlinJsWrappers = "1.0.0-pre.830"
 
 [libraries]
 kotlin-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
 dokka-plugin = { group = "org.jetbrains.dokka", name = "dokka-gradle-plugin", version.ref = "dokka" }
 nexusPublish-plugin = { group = "io.github.gradle-nexus", name = "publish-plugin", version.ref = "nexusPublish" }
-npmPublish-plugin = { group = "dev.petuska", name = "npm-publish-gradle-plugin", version.ref = "npmPublish" }
+npmPublish-plugin = { group = "dev.petuska.npm.publish", name = "dev.petuska.npm.publish.gradle.plugin", version.ref = "npmPublish" }
 
 ionspin-bignum = { group = "com.ionspin.kotlin", name = "bignum", version.ref = "bignum" }
 kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime", version.ref = "kotlinxDatetime"}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/commonMain/kotlin/org/hisp/dhis/lib/expression/spi/ValueType.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/lib/expression/spi/ValueType.kt
@@ -84,7 +84,7 @@ enum class ValueType(internal val default: Any) {
     }
 
     companion object {
-        fun allSame(types: List<ValueType>): Boolean {
+        fun allSame(types: Array<ValueType>): Boolean {
             return types.isEmpty() || types.filter { it != MIXED } .all {it == types[0]}
         }
     }


### PR DESCRIPTION
The initial scope of this PR was to upgrade the Kotlin version (2.0.21). As a side effect of this:
- the Gradle version was updated in order to match the recommended version (gradle 8.12).
  - because of this, the NPM publish plugin needed to be updated. And as a consequence of this:
    - this build script was refactored because of a change of the plugin: in previous versions, the output folder wasn't cleaned between builds, which was used to combine EsModues and CommonJs builds into a same folder (npm hybrid package); in the newest version, the output folder is cleaned between builds, so it is necessary to combine the two builds into a separate folder.
    - the Java version used to run gradle was upgraded to 21. **Important: you will have to change the Java version for Gradle in Intellij to Java 21**

Additionally:
- the Nexus publish plugin (Maven) was updated to its most recent version
- the rest of the libraries were updated.

This PR is published to Maven and NPMJS to test the plugins. The version was incremented in a patch number because there are no functional changes.