### PR TITLE
fix: getApplicationIdentifier logic for *

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ repositories {
     mavenCentral()
 }
 
-version = "1.1.4-SNAPSHOT"
+version = "1.1.5-SNAPSHOT"
 group = "org.hisp.dhis.lib.expression"
 
 if (project.hasProperty("removeSnapshotSuffix")) {

--- a/src/commonMain/kotlin/org/hisp/dhis/lib/expression/math/GS1Elements.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/lib/expression/math/GS1Elements.kt
@@ -302,7 +302,9 @@ enum class GS1Elements(val element: String) {
         fun getApplicationIdentifier(gs1Group: String): String {
             for (gs1Elements in entries) {
                 val name = gs1Elements.element
-                if (name.endsWith("*") && gs1Group.startsWith(name.dropLast(1))) {
+                if (name.endsWith("*")
+                    && gs1Group.length >= name.length
+                    && gs1Group.startsWith(name.dropLast(1))) {
                     return gs1Group.take(name.length);
                 } else if (gs1Group.startsWith(name)) {
                     return name

--- a/src/commonMain/kotlin/org/hisp/dhis/lib/expression/math/GS1Elements.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/lib/expression/math/GS1Elements.kt
@@ -301,15 +301,11 @@ enum class GS1Elements(val element: String) {
 
         fun getApplicationIdentifier(gs1Group: String): String {
             for (gs1Elements in entries) {
-                var ai = gs1Elements.element
-                if (ai.endsWith("*")) {
-                    ai = ai.substring(0, ai.length - 1)
-                }
-                if (gs1Group.startsWith(ai) && ai.endsWith("*")) {
-                    return gs1Group.substring(0, ai.length + 1)
-                }
-                else if (gs1Group.startsWith(ai)) {
-                    return ai
+                val name = gs1Elements.element
+                if (name.endsWith("*") && gs1Group.startsWith(name.dropLast(1))) {
+                    return gs1Group.take(name.length);
+                } else if (gs1Group.startsWith(name)) {
+                    return name
                 }
             }
             throw IllegalArgumentException("Could not retrieve ai from value")

--- a/src/commonTest/kotlin/org/hisp/dhis/lib/expression/math/GS1ElementsTest.kt
+++ b/src/commonTest/kotlin/org/hisp/dhis/lib/expression/math/GS1ElementsTest.kt
@@ -2,6 +2,7 @@ package org.hisp.dhis.lib.expression.math
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 internal class GS1ElementsTest {
 
@@ -30,8 +31,8 @@ internal class GS1ElementsTest {
     @Test
     fun getApplicationIdentifierUsesActualCharacterForStar() {
         assertEquals("250", GS1Elements.getApplicationIdentifier("250"))
-        assertEquals("314", GS1Elements.getApplicationIdentifier("314"))
         assertEquals("3144", GS1Elements.getApplicationIdentifier("3144"))
         assertEquals("3144", GS1Elements.getApplicationIdentifier("31445"))
+        assertFailsWith(IllegalArgumentException::class) { GS1Elements.getApplicationIdentifier("314") }
     }
 }

--- a/src/commonTest/kotlin/org/hisp/dhis/lib/expression/math/GS1ElementsTest.kt
+++ b/src/commonTest/kotlin/org/hisp/dhis/lib/expression/math/GS1ElementsTest.kt
@@ -26,4 +26,12 @@ internal class GS1ElementsTest {
         assertEquals(GS1Elements.PRODUCT_URL, GS1Elements.fromKey("PRODUCT URL"))
         assertEquals(GS1Elements.PRODUCT_URL, GS1Elements.fromKey("PRODUCTURL"))
     }
+
+    @Test
+    fun getApplicationIdentifierUsesActualCharacterForStar() {
+        assertEquals("250", GS1Elements.getApplicationIdentifier("250"))
+        assertEquals("314", GS1Elements.getApplicationIdentifier("314"))
+        assertEquals("3144", GS1Elements.getApplicationIdentifier("3144"))
+        assertEquals("3144", GS1Elements.getApplicationIdentifier("31445"))
+    }
 }


### PR DESCRIPTION
The logic handling names with `*` would get confused because of `ai` being changed half way though. 

The fix is just based on assumptions of how the function should work.