### PR TITLE
[skip publish]: Publish KDoc to github pages

### DIFF
--- a/.github/workflows/dokka.yml
+++ b/.github/workflows/dokka.yml
@@ -1,0 +1,17 @@
+name: Deploy API docs
+
+on:
+  push:
+    branches:
+      - main
+      - master
+
+  workflow_dispatch:
+
+jobs:
+  api-docs:
+    uses: dhis2/workflows/.github/workflows/publish-dokka-to-github-pages.yml@a0b4d50d9606c734b785451774a325846931f1ee
+    with:
+      java_version: 21
+      gradle_args: "-PremoveSnapshotSuffix"
+      output_folder: "api"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.hisp.dhis.lib.expression/expression-parser/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.hisp.dhis.lib.expression/expression-parser)
+[![NPM Version](https://img.shields.io/npm/v/@dhis2/expression-parser)](https://www.npmjs.com/package/@dhis2/expression-parser)
+[![KDoc link](https://img.shields.io/badge/API_reference-KDoc-blue)](https://dhis2.github.io/expression-parser/api/)
+
 # Expression Parser
 
 A parser for the DHIS2 expression language.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 kotlin = "2.0.21"
-dokka = "1.9.0"
+dokka = "2.0.0"
 nexusPublish = "2.0.0"
 npmPublish = "3.5.2"
 apiCompatibility ="0.17.0"


### PR DESCRIPTION
This PR adds a github action to publish API docs to github pages. So far, the link to the docs will only be accessible in the badge in the README file. I have added a few more badges for Maven Central and NPM.

![image](https://github.com/user-attachments/assets/87a9cd38-4032-484f-a911-5f11ed9e178f)


It updates the dokka version just to be up-to-date.

This PRs does not publish a new release, but it does publish the API docs to github pages.