### PR TITLE
[skip publish] chore: Add a job to publish release to github

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,3 +63,11 @@ jobs:
         run: ./.github/workflows/scripts/publish-npm-prod.sh
         env:
           NPMJS_TOKEN: ${{ secrets.DHIS2_BOT_NPM_TOKEN }}
+
+  github-release:
+    uses: dhis2/workflows/.github/workflows/gradle-publish-release-to-github.yml@10b6e0d0662a579b6057a1f7a51a94d41d53a913
+    needs: publish
+    with:
+      java_version: 21
+      gradle_args: "-PremoveSnapshotSuffix"
+


### PR DESCRIPTION
Adds a job to automatically publish a github release on each publication. The job uses a reusable workflow.

This job generates the release notes and attaches them to the release. The version tag has the 'v' suffix, such as "v1.4.0".
