### PR TITLE
fix: [skip publish] coerce null-valued date PRVs to null

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ repositories {
     mavenCentral()
 }
 
-version = "1.1.8-SNAPSHOT"
+version = "1.1.9-SNAPSHOT"
 group = "org.hisp.dhis.lib.expression"
 
 if (project.hasProperty("removeSnapshotSuffix")) {

--- a/src/commonMain/kotlin/org/hisp/dhis/lib/expression/ast/Typed.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/lib/expression/ast/Typed.kt
@@ -33,7 +33,7 @@ fun interface Typed {
 
         fun toDateTypeCoercion(value: Any?): LocalDate? {
             if (value == null) return null
-            if (value is VariableValue) return toDateTypeCoercion(toMixedTypeTypeCoercion(value))
+            if (value is VariableValue) return if (value.value == null) null else toDateTypeCoercion(toMixedTypeTypeCoercion(value))
             if (value is LocalDate) return value
             if (value is String) return LocalDate.parse(value)
             if (value is Instant) return value.toLocalDateTime(TimeZone.currentSystemDefault()).date


### PR DESCRIPTION
This pull request slightly changes how dates from program rule variables are coerced.

Reason for change: Functions like `d2:weeksBetween` would return meaningless results in case one of dates are `null`. This change makes such function calls throw instead when given a `null`-valued program rule variable as argument.