### PR TITLE
chore: Enable manually triggering main workflow in main branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,10 +7,12 @@ on:
     branches:
       - main
 
+  workflow_dispatch:
+
 jobs:
   unit-test:
     name: Run checks
-    if: ${{ github.event.pull_request.merged == true }}
+    if: ${{ github.event.pull_request.merged == true || (github.event_name == 'workflow_dispatch' && github.ref_name == 'main') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -32,7 +34,7 @@ jobs:
   publish:
     name: Publish
     needs: unit-test
-    if: ${{ github.event.pull_request.merged == true && !contains(github.event.pull_request.title, '[skip publish]') }}
+    if: ${{ !contains(github.event.pull_request.title, '[skip publish]') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Adds the `workflow_dispatch` modifier to the main workflow, so it can be manually run if needed. The `workflow_dispatch` will only work in the `main` branch.