### PR TITLE
test: tests for different variable syntax [DHIS2-15858]

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-Xmx1024m


### PR DESCRIPTION
I was wondering if in the context of the ticket this https://github.com/dhis2/expression-parser/blob/main/src/commonMain/kotlin/org/hisp/dhis/lib/expression/syntax/Expr.kt#L346 may be causing issues modelling the name of the variable as `STRING` and not `IDENTIFIER`. I think this is fine. On the parsing level it is correct to make it a `STRING` node as `parseString` is used (allowing any string) whereas an `IDENTIFER` node should originate from `parseIdentifer` (being much more limited). However making the different node types is a burden when handling variables. As far as I can see the child of a variable is mostly handled independent of its type.
I am wondering a bit about this line https://github.com/dhis2/expression-parser/blob/main/src/commonMain/kotlin/org/hisp/dhis/lib/expression/ast/Nodes.kt#L261 that does check for the type.