### PR TITLE
fix: Remove default value for DATE ValueType variables

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ repositories {
     mavenCentral()
 }
 
-version = "1.1.10-SNAPSHOT"
+version = "1.1.12-SNAPSHOT"
 group = "org.hisp.dhis.lib.expression"
 
 if (project.hasProperty("removeSnapshotSuffix")) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ repositories {
     mavenCentral()
 }
 
-version = "1.1.9-SNAPSHOT"
+version = "1.1.10-SNAPSHOT"
 group = "org.hisp.dhis.lib.expression"
 
 if (project.hasProperty("removeSnapshotSuffix")) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ repositories {
     mavenCentral()
 }
 
-version = "1.1.12-SNAPSHOT"
+version = "1.1.10-SNAPSHOT"
 group = "org.hisp.dhis.lib.expression"
 
 if (project.hasProperty("removeSnapshotSuffix")) {

--- a/src/commonMain/kotlin/org/hisp/dhis/lib/expression/ast/Typed.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/lib/expression/ast/Typed.kt
@@ -33,7 +33,7 @@ fun interface Typed {
 
         fun toDateTypeCoercion(value: Any?): LocalDate? {
             if (value == null) return null
-            if (value is VariableValue) return if (value.value == null) null else toDateTypeCoercion(toMixedTypeTypeCoercion(value))
+            if (value is VariableValue) return toDateTypeCoercion(toMixedTypeTypeCoercion(value))
             if (value is LocalDate) return value
             if (value is String) return LocalDate.parse(value)
             if (value is Instant) return value.toLocalDateTime(TimeZone.currentSystemDefault()).date
@@ -53,7 +53,7 @@ fun interface Typed {
                 when (value.valueType) {
                     ValueType.NUMBER -> toNumberTypeCoercion(value.valueOrDefault())
                     ValueType.BOOLEAN -> toBooleanTypeCoercion(value.valueOrDefault())
-                    ValueType.DATE -> toDateTypeCoercion(value.value)
+                    ValueType.DATE -> toDateTypeCoercion(value.valueOrDefault())
                     else -> toStringTypeCoercion(value.valueOrDefault())
                 }
             }

--- a/src/commonMain/kotlin/org/hisp/dhis/lib/expression/ast/Typed.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/lib/expression/ast/Typed.kt
@@ -53,7 +53,7 @@ fun interface Typed {
                 when (value.valueType) {
                     ValueType.NUMBER -> toNumberTypeCoercion(value.valueOrDefault())
                     ValueType.BOOLEAN -> toBooleanTypeCoercion(value.valueOrDefault())
-                    ValueType.DATE -> toDateTypeCoercion(value.valueOrDefault())
+                    ValueType.DATE -> toDateTypeCoercion(value.value)
                     else -> toStringTypeCoercion(value.valueOrDefault())
                 }
             }

--- a/src/commonMain/kotlin/org/hisp/dhis/lib/expression/spi/ValueType.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/lib/expression/spi/ValueType.kt
@@ -21,8 +21,8 @@ enum class ValueType(internal val default: Any?) {
     MIXED(""),
     NUMBER(0.0),
     BOOLEAN(false),
-    DATE("2020-01-01"),
-    STRING(null),
+    DATE(null),
+    STRING(""),
 
     /**
      * Means the type can be mixed but all SAME argument should be of the same actual type. If the return type is also

--- a/src/commonMain/kotlin/org/hisp/dhis/lib/expression/spi/ValueType.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/lib/expression/spi/ValueType.kt
@@ -13,7 +13,7 @@ import kotlin.js.JsExport
  * @author Jan Bernitt
  */
 @JsExport
-enum class ValueType(internal val default: Any) {
+enum class ValueType(internal val default: Any?) {
     /**
      * Type can be at least two of the following: numbers, booleans, dates, strings, list/array of these. This is also
      * used in case a type is unknown or cannot be determined statically.
@@ -22,7 +22,7 @@ enum class ValueType(internal val default: Any) {
     NUMBER(0.0),
     BOOLEAN(false),
     DATE("2020-01-01"),
-    STRING(""),
+    STRING(null),
 
     /**
      * Means the type can be mixed but all SAME argument should be of the same actual type. If the return type is also

--- a/src/commonMain/kotlin/org/hisp/dhis/lib/expression/spi/VariableValue.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/lib/expression/spi/VariableValue.kt
@@ -27,7 +27,7 @@ data class VariableValue(
         require(valueType != ValueType.SAME && valueType != ValueType.MIXED)
     }
 
-    fun valueOrDefault() : Any {
+    fun valueOrDefault() : Any? {
         return value?: valueType.default
     }
 }


### PR DESCRIPTION
A `null` variable with `ValueType` DATE should always be evaluated to `null` and we shouldn't try to fallback to a default value.

This change will fix https://dhis2.atlassian.net/browse/DHIS2-19199