### PR TITLE
feat: Add AndroidCustomIntent evaluation mode

### DIFF
--- a/api/expression-parser.api
+++ b/api/expression-parser.api
@@ -17,6 +17,7 @@ public final class org/hisp/dhis/lib/expression/Expression {
 }
 
 public final class org/hisp/dhis/lib/expression/ExpressionMode : java/lang/Enum {
+	public static final field ANDROID_CUSTOM_INTENT_EXPRESSION Lorg/hisp/dhis/lib/expression/ExpressionMode;
 	public static final field INDICATOR_EXPRESSION Lorg/hisp/dhis/lib/expression/ExpressionMode;
 	public static final field PREDICTOR_GENERATOR_EXPRESSION Lorg/hisp/dhis/lib/expression/ExpressionMode;
 	public static final field PREDICTOR_SKIP_TEST Lorg/hisp/dhis/lib/expression/ExpressionMode;
@@ -358,6 +359,10 @@ public final class org/hisp/dhis/lib/expression/ast/Nodes$AbstractNode$Companion
 }
 
 public final class org/hisp/dhis/lib/expression/ast/Nodes$AggregationTypeNode : org/hisp/dhis/lib/expression/ast/Nodes$SimpleNode {
+	public fun <init> (Lorg/hisp/dhis/lib/expression/ast/NodeType;Ljava/lang/String;)V
+}
+
+public final class org/hisp/dhis/lib/expression/ast/Nodes$AndroidCustomIntentNode : org/hisp/dhis/lib/expression/ast/Nodes$SimpleNode {
 	public fun <init> (Lorg/hisp/dhis/lib/expression/ast/NodeType;Ljava/lang/String;)V
 }
 
@@ -1304,6 +1309,17 @@ public final class org/hisp/dhis/lib/expression/spi/AggregationType : java/lang/
 	public static fun values ()[Lorg/hisp/dhis/lib/expression/spi/AggregationType;
 }
 
+public final class org/hisp/dhis/lib/expression/spi/AndroidCustomIntentVariable : java/lang/Enum {
+	public static final field orgunit_code Lorg/hisp/dhis/lib/expression/spi/AndroidCustomIntentVariable;
+	public static final field orgunit_id Lorg/hisp/dhis/lib/expression/spi/AndroidCustomIntentVariable;
+	public static final field orgunit_path Lorg/hisp/dhis/lib/expression/spi/AndroidCustomIntentVariable;
+	public static final field user_id Lorg/hisp/dhis/lib/expression/spi/AndroidCustomIntentVariable;
+	public static final field user_username Lorg/hisp/dhis/lib/expression/spi/AndroidCustomIntentVariable;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lorg/hisp/dhis/lib/expression/spi/AndroidCustomIntentVariable;
+	public static fun values ()[Lorg/hisp/dhis/lib/expression/spi/AndroidCustomIntentVariable;
+}
+
 public final class org/hisp/dhis/lib/expression/spi/DataItem {
 	public fun <init> (Lorg/hisp/dhis/lib/expression/spi/DataItemType;Lorg/hisp/dhis/lib/expression/spi/ID;Ljava/util/List;Ljava/util/List;Lorg/hisp/dhis/lib/expression/spi/QueryModifiers;)V
 	public fun <init> (Lorg/hisp/dhis/lib/expression/spi/DataItemType;Lorg/hisp/dhis/lib/expression/spi/ID;Lorg/hisp/dhis/lib/expression/spi/QueryModifiers;)V
@@ -1327,6 +1343,7 @@ public final class org/hisp/dhis/lib/expression/spi/DataItem {
 }
 
 public final class org/hisp/dhis/lib/expression/spi/DataItemType : java/lang/Enum {
+	public static final field ANDROID_CUSTOM_INTENT Lorg/hisp/dhis/lib/expression/spi/DataItemType;
 	public static final field ATTRIBUTE Lorg/hisp/dhis/lib/expression/spi/DataItemType;
 	public static final field CONSTANT Lorg/hisp/dhis/lib/expression/spi/DataItemType;
 	public static final field Companion Lorg/hisp/dhis/lib/expression/spi/DataItemType$Companion;
@@ -1504,6 +1521,7 @@ public final class org/hisp/dhis/lib/expression/spi/ID {
 }
 
 public final class org/hisp/dhis/lib/expression/spi/IDType : java/lang/Enum {
+	public static final field AndroidCustomIntent Lorg/hisp/dhis/lib/expression/spi/IDType;
 	public static final field AttributeOptionComboUID Lorg/hisp/dhis/lib/expression/spi/IDType;
 	public static final field AttributeUID Lorg/hisp/dhis/lib/expression/spi/IDType;
 	public static final field CategoryOptionComboUID Lorg/hisp/dhis/lib/expression/spi/IDType;
@@ -1744,6 +1762,7 @@ public final class org/hisp/dhis/lib/expression/syntax/Expr$Companion {
 
 public final class org/hisp/dhis/lib/expression/syntax/ExpressionGrammar {
 	public static final field INSTANCE Lorg/hisp/dhis/lib/expression/syntax/ExpressionGrammar;
+	public final fun getAndroidCustomIntentMode ()Ljava/util/List;
 	public final fun getIndicatorExpressionMode ()Ljava/util/List;
 	public final fun getPredictorExpressionMode ()Ljava/util/List;
 	public final fun getPredictorSkipTestMode ()Ljava/util/List;

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ repositories {
     mavenCentral()
 }
 
-version = "1.2.0-SNAPSHOT"
+version = "1.2.1-SNAPSHOT"
 group = "org.hisp.dhis.lib.expression"
 
 if (project.hasProperty("removeSnapshotSuffix")) {

--- a/src/commonMain/kotlin/org/hisp/dhis/lib/expression/ExpressionMode.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/lib/expression/ExpressionMode.kt
@@ -38,7 +38,10 @@ enum class ExpressionMode(
         ValueType.BOOLEAN,
         ValueType.STRING,
         ValueType.NUMBER,
-        ValueType.DATE);
+        ValueType.DATE),
+
+    // android custom intent request parameters
+    ANDROID_CUSTOM_INTENT_EXPRESSION(ExpressionGrammar.AndroidCustomIntentMode, ValueType.NUMBER);
 
     internal val resultTypes: Set<ValueType> = setOf(*resultTypes)
 

--- a/src/commonMain/kotlin/org/hisp/dhis/lib/expression/ExpressionMode.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/lib/expression/ExpressionMode.kt
@@ -41,7 +41,11 @@ enum class ExpressionMode(
         ValueType.DATE),
 
     // android custom intent request parameters
-    ANDROID_CUSTOM_INTENT_EXPRESSION(ExpressionGrammar.AndroidCustomIntentMode, ValueType.NUMBER);
+    ANDROID_CUSTOM_INTENT_EXPRESSION(
+        ExpressionGrammar.AndroidCustomIntentMode,
+        ValueType.BOOLEAN,
+        ValueType.STRING,
+        ValueType.NUMBER);
 
     internal val resultTypes: Set<ValueType> = setOf(*resultTypes)
 

--- a/src/commonMain/kotlin/org/hisp/dhis/lib/expression/ast/Nodes.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/lib/expression/ast/Nodes.kt
@@ -427,6 +427,10 @@ object Nodes {
             SimpleNode<ProgramVariable>(type, rawValue, ProgramVariable::valueOf, rethrowAs(
                 ProgramVariable::class.simpleName, ProgramVariable.entries, ProgramVariable::name))
 
+    class AndroidCustomIntentNode(type: NodeType, rawValue: String) :
+        SimpleNode<AndroidCustomIntentVariable>(type, rawValue, AndroidCustomIntentVariable::valueOf, rethrowAs(
+            AndroidCustomIntentVariable::class.simpleName, AndroidCustomIntentVariable.entries, AndroidCustomIntentVariable::name))
+
     class NamedValueNode(type: NodeType, rawValue: String) :
             SimpleNode<NamedValue>(type, rawValue, NamedValue::valueOf, rethrowAs(
                 NamedValue::class.simpleName, NamedValue.entries, NamedValue::name))

--- a/src/commonMain/kotlin/org/hisp/dhis/lib/expression/spi/AndroidCustomIntentVariable.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/lib/expression/spi/AndroidCustomIntentVariable.kt
@@ -1,0 +1,12 @@
+package org.hisp.dhis.lib.expression.spi
+
+import kotlin.js.JsExport
+
+@JsExport
+enum class AndroidCustomIntentVariable {
+    orgunit_code,
+    orgunit_id,
+    orgunit_path,
+    user_id,
+    user_username
+}

--- a/src/commonMain/kotlin/org/hisp/dhis/lib/expression/spi/DataItemType.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/lib/expression/spi/DataItemType.kt
@@ -36,7 +36,8 @@ enum class DataItemType(internal val symbol: String, private val parameterTypes:
     INDICATOR("N", IDType.IndicatorUID),
     ORG_UNIT_GROUP("OUG", IDType.OrganisationUnitGroupUID),
     REPORTING_RATE("R", IDType.DataSetUID, IDType.ReportingRateType),
-    PROGRAM_VARIABLE("V", IDType.ProgramVariableName);
+    PROGRAM_VARIABLE("V", IDType.ProgramVariableName),
+    ANDROID_CUSTOM_INTENT("VAR", IDType.AndroidCustomIntent);
 
     constructor(symbol: String, vararg parameterTypes: IDType) : this(
         symbol, listOf<List<IDType>>(listOf<IDType>(*parameterTypes)))

--- a/src/commonMain/kotlin/org/hisp/dhis/lib/expression/spi/IDType.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/lib/expression/spi/IDType.kt
@@ -4,6 +4,7 @@ import kotlin.js.JsExport
 
 @JsExport
 enum class IDType {
+    AndroidCustomIntent,
     AttributeUID,
     AttributeOptionComboUID,
     CategoryOptionUID,
@@ -24,6 +25,6 @@ enum class IDType {
     ReportingRateType;
 
     fun isUID(): Boolean {
-        return this != ProgramVariableName && this != ReportingRateType;
+        return this != ProgramVariableName && this != ReportingRateType && this != AndroidCustomIntent
     }
 }

--- a/src/commonMain/kotlin/org/hisp/dhis/lib/expression/syntax/ExpressionGrammar.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/lib/expression/syntax/ExpressionGrammar.kt
@@ -5,6 +5,7 @@ import org.hisp.dhis.lib.expression.ast.NamedFunction
 import org.hisp.dhis.lib.expression.ast.Node
 import org.hisp.dhis.lib.expression.ast.NodeType
 import org.hisp.dhis.lib.expression.ast.Nodes.AggregationTypeNode
+import org.hisp.dhis.lib.expression.ast.Nodes.AndroidCustomIntentNode
 import org.hisp.dhis.lib.expression.ast.Nodes.ProgramVariableNode
 import org.hisp.dhis.lib.expression.ast.Nodes.ReportingRateTypeNode
 import org.hisp.dhis.lib.expression.spi.DataItemType
@@ -150,6 +151,7 @@ object ExpressionGrammar {
     private val OUG_BRACE = item(DataItemType.ORG_UNIT_GROUP, UID)
     private val N_BRACE = item(DataItemType.INDICATOR, UID)
     private val V_BRACE = variable(DataItemType.PROGRAM_VARIABLE, IDENTIFIER.by(Node.Factory.new(::ProgramVariableNode)))
+    private val ACI_BRACE = variable(DataItemType.ANDROID_CUSTOM_INTENT, IDENTIFIER.by(Node.Factory.new(::AndroidCustomIntentNode)))
     private val CommonDataItems = listOf(HASH_BRACE, A_BRACE, C_BRACE, D_BRACE, I_BRACE, R_BRACE, OUG_BRACE)
 
     /*
@@ -196,6 +198,15 @@ object ExpressionGrammar {
         CommonD2Functions,
         RuleEngineD2Functions,
         listOf(HASH_BRACE, A_BRACE, C_BRACE, V_BRACE))
+
+    val AndroidCustomIntentMode = concat(
+        CommonBooleanFunctions,
+        CommonConstants,
+        CommonNumberFunctions,
+        CommonSameFunctions,
+        CommonD2Functions,
+        RuleEngineD2Functions,
+        listOf(ACI_BRACE))
 
     /*
     Block expressions

--- a/src/commonTest/kotlin/org/hisp/dhis/lib/expression/AndroidCustomIntentExpressionTest.kt
+++ b/src/commonTest/kotlin/org/hisp/dhis/lib/expression/AndroidCustomIntentExpressionTest.kt
@@ -1,0 +1,51 @@
+package org.hisp.dhis.lib.expression
+
+import org.hisp.dhis.lib.expression.spi.ExpressionData
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Tests that the Android Custom Intent mode
+ */
+internal class AndroidCustomIntentExpressionTest {
+
+    @Test
+    fun testLiteralValues() {
+        assertEquals("faJk7SeA5e", evaluate("'faJk7SeA5e'"))
+        assertEquals(5.0, evaluate("5"))
+        assertEquals(5.5, evaluate("5.5"))
+        assertEquals(true, evaluate("true"))
+    }
+
+    @Test
+    fun testSecondLevelOrgunit() {
+        val data = ExpressionData().copy(
+            programVariableValues = mapOf(
+                "orgunit_path" to "/ImspTQPwCqd/O6uvpzGd5pu/YuQRtpLP10I/g8upMTyEZGZ"
+            )
+        )
+
+        assertEquals("O6uvpzGd5pu", evaluate("d2:split(VAR{orgunit_path}, '/', 2)", data))
+    }
+
+    @Test
+    fun testConcatenateUserOrgunit() {
+        val data = ExpressionData().copy(
+            programVariableValues = mapOf(
+                "user_username" to "admin",
+                "orgunit_code" to "OUC32"
+            )
+        )
+
+        assertEquals(
+            "admin_OUC32",
+            evaluate("d2:concatenate(VAR{user_username}, '_', VAR{orgunit_code})", data)
+        )
+    }
+
+    companion object {
+        private fun evaluate(expression: String, data: ExpressionData = ExpressionData()): Any? {
+            return Expression(expression, ExpressionMode.ANDROID_CUSTOM_INTENT_EXPRESSION).evaluate(data)
+        }
+    }
+}

--- a/src/commonTest/kotlin/org/hisp/dhis/lib/expression/AndroidCustomIntentExpressionTest.kt
+++ b/src/commonTest/kotlin/org/hisp/dhis/lib/expression/AndroidCustomIntentExpressionTest.kt
@@ -1,8 +1,11 @@
 package org.hisp.dhis.lib.expression
 
 import org.hisp.dhis.lib.expression.spi.ExpressionData
+import org.hisp.dhis.lib.expression.spi.ParseException
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 /**
  * Tests that the Android Custom Intent mode
@@ -43,9 +46,24 @@ internal class AndroidCustomIntentExpressionTest {
         )
     }
 
+    @Test
+    fun testValidateExpression() {
+        validate("VAR{orgunit_code}", valid = true)
+        validate("VAR{invalid_var}", valid = false)
+    }
+
     companion object {
         private fun evaluate(expression: String, data: ExpressionData = ExpressionData()): Any? {
             return Expression(expression, ExpressionMode.ANDROID_CUSTOM_INTENT_EXPRESSION).evaluate(data)
+        }
+
+        private fun validate(expression: String, valid: Boolean) {
+            try {
+                Expression(expression, ExpressionMode.ANDROID_CUSTOM_INTENT_EXPRESSION).validate(mapOf())
+                assertTrue(valid)
+            } catch (e: ParseException) {
+                assertFalse(valid)
+            }
         }
     }
 }


### PR DESCRIPTION
This PR adds a new evaluation mode for Android Custom Intents.

There is a predefined list of supported variables (`AndroidCustomIntentVariable`). Their value must be provided by the client using the `ExpressionData.programVariableValues` property. This is an abuse of the model, but it was agreed to use this property to avoid breaking changes in the API.

The mode includes some D2 functions, which are needed in the known use cases of custom intents. 