### PR TITLE
chore: [skip publish] Use DHIS2 Bot sonar token

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Run SonarCloud Analysis
         run: ./gradlew sonar
         env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.DHIS2_BOT_SONARCLOUD_TOKEN }}
           GIT_BRANCH: ${{ github.ref_name }}
 
   publish:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Run SonarCloud Analysis
         run: ./gradlew sonar
         env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.DHIS2_BOT_SONARCLOUD_TOKEN }}
           GIT_BRANCH: ${{ github.ref_name}}
           GIT_BRANCH_DEST: ${{ github.base_ref }}
           PULL_REQUEST: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
It changes the SonarCloud token: use the existing DHIS2 Bot sonar token instead of a personal one. The "SONAR_TOKEN" repository secret will be removed once this PR is merged.