### PR TITLE
fix: Do not escape regex in d2:validatePattern [DHIS2-21359]

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ repositories {
     mavenCentral()
 }
 
-version = "1.4.1-SNAPSHOT"
+version = "1.4.2-SNAPSHOT"
 group = "org.hisp.dhis.lib.expression"
 
 if (project.hasProperty("removeSnapshotSuffix")) {

--- a/src/commonMain/kotlin/org/hisp/dhis/lib/expression/ast/Nodes.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/lib/expression/ast/Nodes.kt
@@ -366,7 +366,7 @@ object Nodes {
              * a hyphen inside a character class is treated as a literal and cannot form an
              * unintended range. Both Java and JS unicode-mode regex accept \-.
              */
-            fun decodeToRegex(rawValue: String): String {
+            internal fun decodeToRegex(rawValue: String): String {
                 if (rawValue.indexOf('\\') < 0) return rawValue
                 val str = StringBuilder()
                 val chars = rawValue.toCharArray()

--- a/src/commonMain/kotlin/org/hisp/dhis/lib/expression/ast/Nodes.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/lib/expression/ast/Nodes.kt
@@ -356,6 +356,45 @@ object Nodes {
                 }
                 return str.toString()
             }
+
+            /**
+             * Processes a raw expression-string value for use as a regex pattern on all platforms.
+             *
+             * Strips backslashes from expression-level escapes (e.g. \' -> ', \ -> ' ')
+             * but preserves standard regex escapes (\d, \w, \s, \uXXXX, etc.) so the
+             * regex engine receives them intact. In particular, \- is kept as \- so that
+             * a hyphen inside a character class is treated as a literal and cannot form an
+             * unintended range. Both Java and JS unicode-mode regex accept \-.
+             */
+            fun decodeToRegex(rawValue: String): String {
+                if (rawValue.indexOf('\\') < 0) return rawValue
+                val str = StringBuilder()
+                val chars = rawValue.toCharArray()
+                var i = 0
+                while (i < chars.size) {
+                    val c = chars[i++]
+                    if (c != '\\' || i >= chars.size) {
+                        str.append(c)
+                        continue
+                    }
+                    val next = chars[i++]
+                    when (next) {
+                        't', 'n', 'r', 'f', 'b',
+                        '\\', '^', '$', '.', '*', '+', '?', '(', ')', '[', ']', '{', '}', '|',
+                        '-', 'd', 'D', 'w', 'W', 's', 'S', 'B', 'p', 'P' -> str.append('\\').append(next)
+                        'u' -> {
+                            str.append('\\').append('u')
+                            repeat(4) { if (i < chars.size) str.append(chars[i++]) }
+                        }
+                        'x' -> {
+                            str.append('\\').append('x')
+                            repeat(2) { if (i < chars.size) str.append(chars[i++]) }
+                        }
+                        else -> str.append(next)
+                    }
+                }
+                return str.toString()
+            }
         }
     }
 

--- a/src/commonMain/kotlin/org/hisp/dhis/lib/expression/ast/Nodes.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/lib/expression/ast/Nodes.kt
@@ -356,45 +356,6 @@ object Nodes {
                 }
                 return str.toString()
             }
-
-            /**
-             * Processes a raw expression-string value for use as a regex pattern on all platforms.
-             *
-             * Strips backslashes from expression-level escapes (e.g. \' -> ', \ -> ' ')
-             * but preserves standard regex escapes (\d, \w, \s, \uXXXX, etc.) so the
-             * regex engine receives them intact. In particular, \- is kept as \- so that
-             * a hyphen inside a character class is treated as a literal and cannot form an
-             * unintended range. Both Java and JS unicode-mode regex accept \-.
-             */
-            internal fun decodeToRegex(rawValue: String): String {
-                if (rawValue.indexOf('\\') < 0) return rawValue
-                val str = StringBuilder()
-                val chars = rawValue.toCharArray()
-                var i = 0
-                while (i < chars.size) {
-                    val c = chars[i++]
-                    if (c != '\\' || i >= chars.size) {
-                        str.append(c)
-                        continue
-                    }
-                    val next = chars[i++]
-                    when (next) {
-                        't', 'n', 'r', 'f', 'b',
-                        '\\', '^', '$', '.', '*', '+', '?', '(', ')', '[', ']', '{', '}', '|',
-                        '-', 'd', 'D', 'w', 'W', 's', 'S', 'B', 'p', 'P' -> str.append('\\').append(next)
-                        'u' -> {
-                            str.append('\\').append('u')
-                            repeat(4) { if (i < chars.size) str.append(chars[i++]) }
-                        }
-                        'x' -> {
-                            str.append('\\').append('x')
-                            repeat(2) { if (i < chars.size) str.append(chars[i++]) }
-                        }
-                        else -> str.append(next)
-                    }
-                }
-                return str.toString()
-            }
         }
     }
 

--- a/src/commonMain/kotlin/org/hisp/dhis/lib/expression/eval/Calculator.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/lib/expression/eval/Calculator.kt
@@ -2,6 +2,7 @@ package org.hisp.dhis.lib.expression.eval
 
 import kotlinx.datetime.LocalDate
 import org.hisp.dhis.lib.expression.ast.*
+import org.hisp.dhis.lib.expression.ast.Nodes.Utf8StringNode
 import org.hisp.dhis.lib.expression.ast.UnaryOperator.Companion.negate
 import org.hisp.dhis.lib.expression.spi.*
 
@@ -303,7 +304,7 @@ internal class Calculator(
 
     private fun evalToRawString(node: Node<*>): String? {
         return when (node.getType()) {
-            NodeType.STRING -> node.getRawValue()
+            NodeType.STRING -> Utf8StringNode.decodeToRegex(node.getRawValue())
             NodeType.ARGUMENT -> evalToRawString(node.child(0))
             NodeType.PAR -> evalToRawString(node.child(0))
             else -> evalToString(node)

--- a/src/commonMain/kotlin/org/hisp/dhis/lib/expression/eval/Calculator.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/lib/expression/eval/Calculator.kt
@@ -139,7 +139,7 @@ internal class Calculator(
                 evalToInteger(fn.child(2)))
             NamedFunction.d2_validatePattern -> functions.d2_validatePattern(
                 evalToString(fn.child(0)),
-                evalToString(fn.child(1)))
+                evalToRawString(fn.child(1)))
             NamedFunction.d2_weeksBetween -> functions.d2_weeksBetween(
                 evalToDate(fn.child(0)),
                 evalToDate(fn.child(1)))
@@ -299,6 +299,15 @@ internal class Calculator(
 
     fun evalToString(node: Node<*>): String? {
         return eval(node, "String", Typed::toStringTypeCoercion)
+    }
+
+    private fun evalToRawString(node: Node<*>): String? {
+        return when (node.getType()) {
+            NodeType.STRING -> node.getRawValue()
+            NodeType.ARGUMENT -> evalToRawString(node.child(0))
+            NodeType.PAR -> evalToRawString(node.child(0))
+            else -> evalToString(node)
+        }
     }
 
     fun evalToBoolean(node: Node<*>): Boolean? {

--- a/src/commonMain/kotlin/org/hisp/dhis/lib/expression/eval/Calculator.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/lib/expression/eval/Calculator.kt
@@ -304,7 +304,7 @@ internal class Calculator(
 
     private fun evalToRawString(node: Node<*>): String? {
         return when (node.getType()) {
-            NodeType.STRING -> Utf8StringNode.decodeToRegex(node.getRawValue())
+            NodeType.STRING -> node.getRawValue()
             NodeType.ARGUMENT -> evalToRawString(node.child(0))
             NodeType.PAR -> evalToRawString(node.child(0))
             else -> evalToString(node)

--- a/src/commonMain/kotlin/org/hisp/dhis/lib/expression/spi/ExpressionFunctions.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/lib/expression/spi/ExpressionFunctions.kt
@@ -315,7 +315,7 @@ fun interface ExpressionFunctions {
     }
 
     fun d2_validatePattern(input: String?, regex: String?): Boolean {
-        return input != null && regex != null && input.matches(regex.toRegex())
+        return input != null && regex != null && matchesPattern(input, regex)
     }
 
     fun d2_weeksBetween(start: LocalDate?, end: LocalDate?): Int {

--- a/src/commonMain/kotlin/org/hisp/dhis/lib/expression/spi/RegexMatch.kt
+++ b/src/commonMain/kotlin/org/hisp/dhis/lib/expression/spi/RegexMatch.kt
@@ -1,0 +1,3 @@
+package org.hisp.dhis.lib.expression.spi
+
+internal expect fun matchesPattern(input: String, pattern: String): Boolean

--- a/src/commonTest/kotlin/org/hisp/dhis/lib/expression/function/ValidatePatternTest.kt
+++ b/src/commonTest/kotlin/org/hisp/dhis/lib/expression/function/ValidatePatternTest.kt
@@ -29,12 +29,14 @@ internal class ValidatePatternTest {
     fun testValidatePattern_Match() {
         assertTrue(evaluate("d2:validatePattern(\"124\", \"[0-9]+\")"))
         assertTrue(evaluate("d2:validatePattern(\"12x4\", \"[0-9x]+\")"))
+        assertTrue(evaluate("d2:validatePattern(\"John\",(\"[a-zA-Z0-9À-ȕ\\'\\-\\‘\\`\\’\\ ]+\"))"))
     }
 
     @Test
     fun testValidatePattern_NoMatch() {
         assertFalse(evaluate("d2:validatePattern(\"12x4\", \"[0-9]+\")"))
         assertFalse(evaluate("d2:validatePattern(\"ab0\", \"[0-9x]+\")"))
+        assertFalse(evaluate("d2:validatePattern(\"Иван\",(\"[a-zA-Z0-9À-ȕ\\'\\-\\‘\\`\\’\\ ]+\"))"))
     }
 
     private fun evaluate(expression: String): Boolean {

--- a/src/jsMain/kotlin/org/hisp/dhis/lib/expression/spi/RegexMatch.kt
+++ b/src/jsMain/kotlin/org/hisp/dhis/lib/expression/spi/RegexMatch.kt
@@ -1,0 +1,7 @@
+package org.hisp.dhis.lib.expression.spi
+
+internal actual fun matchesPattern(input: String, pattern: String): Boolean {
+    // Avoid Kotlin stdlib's Regex wrapper which may add the JS `u` flag and reject unknown backslash
+    // escapes. Use RegExp directly with ^(?:...)$ anchoring to replicate full-string matching.
+    return js("new RegExp('^(?:' + pattern + ')$').test(input)") as Boolean
+}

--- a/src/jvmMain/kotlin/org/hisp/dhis/lib/expression/spi/RegexMatch.kt
+++ b/src/jvmMain/kotlin/org/hisp/dhis/lib/expression/spi/RegexMatch.kt
@@ -1,0 +1,4 @@
+package org.hisp.dhis.lib.expression.spi
+
+internal actual fun matchesPattern(input: String, pattern: String): Boolean =
+    input.matches(pattern.toRegex())

--- a/src/nativeMain/kotlin/org/hisp/dhis/lib/expression/spi/RegexMatch.kt
+++ b/src/nativeMain/kotlin/org/hisp/dhis/lib/expression/spi/RegexMatch.kt
@@ -1,0 +1,4 @@
+package org.hisp.dhis.lib.expression.spi
+
+internal actual fun matchesPattern(input: String, pattern: String): Boolean =
+    input.matches(pattern.toRegex())


### PR DESCRIPTION
### Problem               
                                                                                                                                                                                                
  Two bugs combined to break `d2:validatePattern`, one affecting all platforms and one affecting                                                                                                
  Kotlin/JS only.
                                                                                                                                                                                                
  **Bug 1 — pattern was string-decoded before reaching the regex engine (all platforms)**                                                                                                       
   
  The regex pattern argument was evaluated with `evalToString`, which applies full expression-string                                                                                            
  decoding: every backslash escape is resolved as if it were a string literal. This silently corrupted
  the pattern passed to the regex engine:                                                                                                                                                       
                                                                                                                                                                                                
  | Pattern as written | After `evalToString` | Effect |                                                                                                                                        
  |---|---|---|                                                                                                                                                                                 
  | `\d` | `d` | digit class lost, matches literal `d` only |                                                                                                                                   
  | `\w` | `w` | word class lost |                                                                                                                                                              
  | `\-` inside `[...]` | `-` | hyphen becomes a range operator, creating unintended ranges |                                                                                                   
                                                                                                                                                                                                
  The fix is to use `evalToRawString`, which returns the node's raw value without applying                                                                                                      
  string-escape decoding, so the regex engine receives the pattern as the author intended.                                                                                                      
                                                                                                                                                                                                
  **Bug 2 — raw pattern rejected by the JS regex engine (Kotlin/JS only)**                                                                                                                      
                                                                                                                                                                                                
  After fixing Bug 1, the raw expression-string value reaches the JS regex engine intact. The raw                                                                                               
  value preserves expression-language escapes that have no equivalent in the regex spec, such as `\'`,
  `` \` ``, and `\ `. The Kotlin stdlib `Regex` wrapper applies the JavaScript **Unicode mode**                                                                                                 
  (`u` flag) unconditionally. Under Unicode mode, ECMAScript withdraws the Annex B leniency rules                                                                                               
  and permits only a strict subset of backslash escapes, causing any unknown one to throw a                                                                                                     
  `SyntaxError` at construction time.                                                                                                                                                           
                                                                                                                                                                                                
  The relevant test case illustrates this — the raw pattern string reaching the engine is:                                                                                                      
                            
  ```                                                                                                                                                                                           
  [a-zA-Z0-9À-ȕ\'\-\'\`\'\ ]+
  ```                                                                                                                                                                                           
   
  | Escape | Origin | JVM (`java.util.regex`) | JS — no `u` flag | JS — `u` flag (Kotlin stdlib) |                                                                                              
  |--------|--------|-------------------------|------------------|-------------------------------|
  | `\'`   | Expression-language quote escape    | ✅ identity escape → `'`      | ✅ ECMAScript Annex B → `'`      | ❌ `SyntaxError` — not a syntax character |                                  
  | `\-`   | Literal hyphen in character class   | ✅ literal `-`                | ✅ literal `-`                   | ✅ explicit `ClassEscape` in Unicode mode |                                  
  | `` \` `` | Expression-language backtick escape | ✅ identity escape → `` ` `` | ✅ ECMAScript Annex B → `` ` `` | ❌ `SyntaxError` — not a syntax character |                                  
  | `\ `   | Expression-language space escape    | ✅ identity escape → ` `      | ✅ ECMAScript Annex B → ` `      | ❌ `SyntaxError` — not a syntax character |                                  
                                                                                                                                                                                                
  There is no API knob on the Kotlin stdlib `Regex` to suppress the `u` flag on the JS target.                                                                                                  
                                                                                                                                                                                                
  ### Solution                                                                                                                                                                                  
                            
  **Bug 1** is fixed by introducing `evalToRawString` in `Calculator` and routing the pattern                                                                                                   
  argument of `d2:validatePattern` through it instead of `evalToString`.
                                                                                                                                                                                                
  **Bug 2** is fixed by introducing a `matchesPattern` `expect`/`actual` function:                                                                                                              
                                                                                                                                                                                                
  - **`commonMain`** — declares the `expect`                                                                                                                                                    
  - **`jvmMain` / `nativeMain`** — delegates to `input.matches(pattern.toRegex())` unchanged
  - **`jsMain`** — constructs the `RegExp` directly via `js(...)`, bypassing the stdlib wrapper and                                                                                             
    therefore the `u` flag; wraps the pattern in `^(?:...)$` to replicate Kotlin's full-string                                                                                                  
    matching semantics                                                                                                                                                                          
                                                                                                                                                                                                
  `d2_validatePattern` now calls `matchesPattern` instead of `input.matches(regex.toRegex())`.                                                                                                  
                            
  ### Trade-off                                                                                                                                                                                 
                            
  Running without the `u` flag means Unicode property escapes (`\p{Lu}` etc.) are not interpreted                                                                                               
  by the JS engine — the pattern is accepted without error but `\p{Lu}` behaves as the literal
  string `p{Lu}`. For DHIS2's validation patterns (digit ranges, character sets, simple anchors)                                                                                                
  this is not a concern in practice, and the JVM target continues to interpret them correctly via                                                                                               
  Java's `Pattern`. 